### PR TITLE
Fix icon link for PWA

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -8,7 +8,7 @@
   "orientation": "landscape-primary",
   "icons": [
     {
-      "src": "./assets/icon.png",
+      "src": "/icon.png",
       "type": "image/png",
       "sizes": "512x512"
     }


### PR DESCRIPTION
The website currently does not ask to be installed as a PWA since the icon link in `manifest.json` is broken. This fixes the issue.